### PR TITLE
A variety of UI and Quality of Life fixes

### DIFF
--- a/Source/TWSMainPanel.cpp
+++ b/Source/TWSMainPanel.cpp
@@ -543,6 +543,22 @@ TWSMainPanel::TWSMainPanel (TuningworkbenchsynthAudioProcessor &p)
     DelayPower->addListener(this);
     ModWheelPower->addListener(this);
     FilterPower->addListener(this);
+
+    /*
+    ** set up the range functions
+    */
+    auto freqMapTop01 = [](double start, double end, double value ) {
+                            std::cout << "TO: " << start << " " << end << " " << value << std::endl;
+                            return value;
+                        };
+    auto freqMapFrom01 = [](double start, double end, double value ) {
+                            std::cout << "FR: " << start << " " << end << " " << value << std::endl;
+                            return value;
+                        };
+    NormalisableRange<double> filtfrange( 10, 20000, freqMapFrom01, freqMapTop01 );
+    Filt_Cutoff->setNormalisableRange( filtfrange );
+
+    
     //[/UserPreSize]
 
     setSize (784, 730);

--- a/Source/TWSTuningGrid.cpp
+++ b/Source/TWSTuningGrid.cpp
@@ -51,7 +51,7 @@ TWSTuningGrid::TWSTuningGrid ()
     table->setModel( this );
 
     table->getViewport()->setScrollBarsShown(true,false);
-    table->getViewport()->setViewPositionProportionately( 55.0 / 127.0, 0.0 );
+    table->getViewport()->setViewPositionProportionately( 0.0,  60.0 / 127.0 );
 
     for( int i=0; i<128; ++i )
         notesOn[i] = false;
@@ -90,7 +90,7 @@ void TWSTuningGrid::resized()
     table->setBounds (0, 0, proportionOfWidth (1.0000f), proportionOfHeight (1.0000f));
     //[UserResized] Add your own custom resize handling here..
     table->getViewport()->setScrollBarsShown(true,false);
-    table->getViewport()->setViewPositionProportionately( 55.0 / 127.0, 0.0 );
+    table->getViewport()->setViewPositionProportionately( 0.0, 60.0 / 127.0 );
     //[/UserResized]
 }
 


### PR DESCRIPTION
- If no VCO is powered on and you play a note, turn
  on the analog ones. Closes #59.
- Smooth the delay values. Closes #52
- Use exponential scales for frequencies and envelope
  times. Closes #28