### PR TITLE
Fix button listeners

### DIFF
--- a/Source/TWSMainPanel.h
+++ b/Source/TWSMainPanel.h
@@ -31,6 +31,7 @@ public:
     virtual void paintButton( Graphics &g, bool hl, bool dn );
 };
 
+
 struct TWSLambdaParamListener : public virtual AudioProcessorParameter::Listener
 {
     virtual void parameterGestureChanged( int, bool ) { }
@@ -87,7 +88,7 @@ private:
     std::vector<std::unique_ptr<SliderAttachment>> sliderAttachments;
     typedef AudioProcessorValueTreeState::ButtonAttachment ButtonAttachment;
     std::vector<std::unique_ptr<ButtonAttachment>> buttonAttachments;
-    std::vector<TWSLambdaParamListener*> lambdaAtttachments;
+    std::vector<std::pair<std::string,TWSLambdaParamListener*>> lambdaAtttachments;
     std::unique_ptr<PopupMenu> presetMenu;
 
     //[/UserVariables]

--- a/scripts/projuce-mac-vst2.sh
+++ b/scripts/projuce-mac-vst2.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ -z $VST2SDK_DIR ]; then
+    echo "VST2SDK_DIR is not set. Please point it to a directory containing the VST2 SDK"
+    exit 1
+else
+   sed -e 's/buildVST3,b/buildVST,b/' tuning-workbench-synth.jucer | \
+	sed -e "s@VST2SDK_DIR@${VST2SDK_DIR}@" | \
+	sed -e 's/PLUGINHOST_VST="0"/PLUGINHOST_VST="1"/' | \
+	sed -e 's/buildVST="0"/buildVST="1"/' > tuning-workbench-synth-vst2.jucer
+   mv tuning-workbench-synth.jucer tuning-workbench-synth-orig.jucer
+   mv tuning-workbench-synth-vst2.jucer tuning-workbench-synth.jucer
+   assets/JUCE/Projucer.app/Contents/MacOS/Projucer --resave tuning-workbench-synth.jucer
+   mv tuning-workbench-synth-orig.jucer tuning-workbench-synth.jucer
+fi
+

--- a/tuning-workbench-synth.jucer
+++ b/tuning-workbench-synth.jucer
@@ -84,7 +84,7 @@
     </GROUP>
   </MAINGROUP>
   <EXPORTFORMATS>
-    <XCODE_MAC targetFolder="Builds/MacOSX" vst3Folder="./lib/vst3sdk" extraCompilerFlags="-DJUCE_DISPLAY_SPLASH_SCREEN=0 -DJUCE_REPORT_APP_USAGE=0 -I../../lib/tuning-library/include -Werror"
+    <XCODE_MAC targetFolder="Builds/MacOSX" vst3Folder="./lib/vst3sdk" extraCompilerFlags="-DJUCE_DISPLAY_SPLASH_SCREEN=0 -DJUCE_REPORT_APP_USAGE=0 -I../../lib/tuning-library/include -Werror" vstLegacyFolder="VST2SDK_DIR" 
                smallIcon="qyAsbP" bigIcon="EBwV9t">
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug"/>


### PR DESCRIPTION
The hokey button listeners I had that worked had a memory problem
which was exposed by the VST2. Replace them with a proper use
of ButtonAttachment (duh - why didn't I do that first time) and
also clean up the tri-state listeners too.

Closes #91