### PR TITLE
Remove incorrect old code

### DIFF
--- a/Source/TWSMainPanel.cpp
+++ b/Source/TWSMainPanel.cpp
@@ -628,7 +628,6 @@ TWSMainPanel::TWSMainPanel (TuningworkbenchsynthAudioProcessor &p)
 
 
     //[Constructor] You can add your own custom stuff here..
-    sineMix->setValue( 1.0 );
     //[/Constructor]
 }
 


### PR DESCRIPTION
Some old code set sineMix to 1 in the constructor from the very
first alpha version. That blew up LInux VST2 and was wrong. Remove

Closes #101