### PR TITLE
Revert the MidiBuffer Iterator

### DIFF
--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -354,15 +354,16 @@ void TuningworkbenchsynthAudioProcessor::processBlock (AudioBuffer<float>& buffe
     if( noteListeners.size() > 0 )
     {
         bool noteTog = false;
-        MidiBufferIterator midiIterator  = midiMessages.begin();
+        MidiBuffer::Iterator midiIterator (midiMessages);
+        midiIterator.setNextSamplePosition (0);
         int midiEventPos;
+        MidiMessage m;
 
         int ons[127], offs[127];
         int onp=0, offp=0;
 
-        while( midiIterator != midiMessages.end() )
+        while( midiIterator.getNextEvent(m, midiEventPos ) )
         {
-            auto m = (*midiIterator).getMessage();
             if( m.isNoteOn() )
             {
                 ons[onp++] = m.getNoteNumber();


### PR DESCRIPTION
That had crashed in JUCE6 because I tested it poorly. Revert for
now